### PR TITLE
changed router implementation to use a plain onRun hook in order to be more independent from the different route functions

### DIFF
--- a/lib/client/router.js
+++ b/lib/client/router.js
@@ -1,52 +1,22 @@
-var _super = {
-  route: Router.route
-};
-
-Router.route = function(name, options) {
-  options = attachAnalyticsOptions.call(this, options);
-  return _super.route.call(this, name, options);
-};
-
-var attachAnalyticsOptions = function(options) {
-  options = options || {};
-
-  if (shouldSendVirtualPageview.call(this, options)) {
-    attachVirtualPageviewSender.call(this, options);
+Router.onRun(function () {
+  if (shouldSendVirtualPageview(Router.options, this.route.options)) {
+    gtmBulldozer.bulldoze();
+    dataLayer.push({
+      event: 'VirtualPageview',
+      virtualPageURL: this.url
+    });
   }
+  this.next();
+});
 
-  return options;
-};
-
-var shouldSendVirtualPageview = function(options) {
+function shouldSendVirtualPageview(routerOptions, routeOptions) {
   if (typeof (window.dataLayer) === 'undefined') {
     return false;
   }
 
-  if (options && typeof options.trackPageView !== 'undefined') {
-    return !!options.trackPageView;
+  if (routeOptions && typeof routeOptions.trackPageView !== 'undefined') {
+    return !!routeOptions.trackPageView;
   }
 
-  return !!this.options && !!this.options.trackPageView;
-};
-
-var attachVirtualPageviewSender = function(options) {
-  var originalOnRun = options.onRun;
-
-  options.onRun = function() {
-    gtmBulldozer.bulldoze();
-    dataLayer.push({
-      event: 'VirtualPageview',
-      virtualPageURL: arguments[0].url
-    });
-
-    return callEventHandlerOrNext.call(this, originalOnRun, arguments);
-  };
-};
-
-var callEventHandlerOrNext = function(handler, args) {
-  if (handler) {
-    return handler.apply(this, [].slice.apply(args));
-  } else {
-    this.next();
-  }
+  return !!routerOptions && !!routerOptions.trackPageView;
 };


### PR DESCRIPTION
the current implementation is basically monkey patching the `route` method instead of providing a `onRun` hook. this makes the implementation not robust against changes of the route api and does not leverage the public api for extending routing behaviour.

the result of this is that the code actually only works for the single route function which is patched, but there are currently 3 different implementations:
- `route(path, function)`
- `route(path)`
- `route(path, function, options)`

in my concrete case my options, e.g. a route name, are ignored and the path is taken as the default name which includes the parameters which in return breaks existing logic which depends on the actual name instead of the path.
