### PR TITLE
added query parameters and hash fragments to reported url

### DIFF
--- a/lib/client/router.js
+++ b/lib/client/router.js
@@ -3,7 +3,7 @@ Router.onRun(function () {
     gtmBulldozer.bulldoze();
     dataLayer.push({
       event: 'VirtualPageview',
-      virtualPageURL: this.url
+      virtualPageURL: this.route.path(this.params, this.params)
     });
   }
   this.next();

--- a/package.js
+++ b/package.js
@@ -1,3 +1,9 @@
+/**
+ * HACK INFORMATION
+ * ================
+ * This package was inlined, because it got extended with a fix for query parameters and hash fragment.
+ */
+
 Package.describe({
   name: 'gorillastack:iron-router-gtm',
   version: '0.2.0',


### PR DESCRIPTION
currently only the path without any query parameters or hash fragments is reported. this leads to problems when integrating for example adwords with analytics. the missing gclid parameter which adwords attaches but which is not reported to analytics (through gtm) causes analytics to not associate the sessions with the adwords click.

I imagine there are plenty similar issues.

btw. the `this.route.path(this.params, this.params)` is kind of a hack, because I did not know a better way to extract path, query and hash parameters in a more elegant way. I am open for suggestions.
